### PR TITLE
Assorted dependency updates

### DIFF
--- a/spng-sys/Cargo.toml
+++ b/spng-sys/Cargo.toml
@@ -12,7 +12,7 @@ description = "Native bindings to libspng"
 readme = "../README.md"
 
 [dependencies]
-libz-sys = { version = "1.1.2", default-features = false, features = ["libc", "static"] }
+libz-sys = { version = "1.1.14", default-features = false, features = ["libc", "static"] }
 libc = "0.2"
 
 [build-dependencies]

--- a/spng/Cargo.toml
+++ b/spng/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 spng-sys = { version = "0.2.0-alpha.2", path = "../spng-sys" }
-bitflags = "1.2"
+bitflags = "2.4.1"
 libc = "0.2"
 
 [features]

--- a/spng/src/lib.rs
+++ b/spng/src/lib.rs
@@ -138,6 +138,7 @@ impl TryFrom<u8> for BitDepth {
 
 bitflags::bitflags! {
     /// Decoding flags
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
     pub struct DecodeFlags: u32 {
         /// Apply transparency
         const TRANSPARENCY = sys::spng_decode_flags_SPNG_DECODE_TRNS;
@@ -151,6 +152,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
     pub struct ContextFlags: u32 {
         /// Ignore checksum in `DEFLATE` streams
         const IGNORE_ADLER32 = sys::spng_ctx_flags_SPNG_CTX_IGNORE_ADLER32;

--- a/spng/src/raw.rs
+++ b/spng/src/raw.rs
@@ -424,7 +424,7 @@ impl<R> RawContext<R> {
                 out.as_mut_ptr() as _,
                 out.len(),
                 out_format as _,
-                flags.bits as _,
+                flags.bits() as _,
             ))
         }
     }


### PR DESCRIPTION
This is just a small commit for updating non-development dependencies to their latest versions. No functional changes are expected, but the usage of `bitflags` v2 instead of v1 should lead to Cargo avoiding building both v1 and v2 for projects that use, directly or indirectly, the newer `bitflags` version.