### PR TITLE
Let `spng-sys` crate users choose whether to link to libz statically

### DIFF
--- a/spng-sys/Cargo.toml
+++ b/spng-sys/Cargo.toml
@@ -12,12 +12,12 @@ description = "Native bindings to libspng"
 readme = "../README.md"
 
 [dependencies]
-libz-sys = { version = "1.1.2", default-features = false, features = ["libc", "static"] }
+libz-sys = { version = "1.1.2", default-features = false, features = ["libc"] }
 libc = "0.2"
 
 [build-dependencies]
 cc = "1.0"
 
 [features]
-default = []
+default = ["libz-sys/static"]
 zlib-ng = ["libz-sys/zlib-ng"]


### PR DESCRIPTION
Letting advanced users choose how `spng-sys` links to Zlib may be very useful. I have decided to not expose this flag to `spng` as I think that statically linking to Zlib is the most user-friendly behavior by default.