### PR TITLE
Stop replicating `libz-sys` logic for linking to `libz`

### DIFF
--- a/spng-sys/build.rs
+++ b/spng-sys/build.rs
@@ -15,26 +15,4 @@ fn main() {
 
     // DEP_SPNG_INCLUDE for other crates
     println!("cargo:include=libspng/spng");
-
-    println!("cargo:rustc-link-lib=static={}", libname());
-}
-
-#[cfg(not(feature = "zlib-ng"))]
-fn libname() -> &'static str {
-    "z"
-}
-
-#[cfg(feature = "zlib-ng")]
-fn libname() -> &'static str {
-    let target = env::var("TARGET").unwrap();
-    // Derived from: https://github.com/rust-lang/libz-sys/blob/36b3071331d9a87712c9d23fd7aea79208425c73/build.rs#L167
-    if target.contains("windows") {
-        if target.contains("msvc") && env::var("OPT_LEVEL").unwrap() == "0" {
-            "zlibstaticd"
-        } else {
-            "zlibstatic"
-        }
-    } else {
-        "z"
-    }
 }

--- a/spng-sys/src/lib.rs
+++ b/spng-sys/src/lib.rs
@@ -8,6 +8,11 @@ mod ffi;
 
 pub use ffi::*;
 
+// Declaring this crate as extern is needed so that the Rust compiler thinks libz
+// is used, and thus passes the expected parameters to get libz linked in. See:
+// https://github.com/dtolnay/link-cplusplus/blob/75a186c35babbb7b39d0e5c544e1dfc9cc704800/README.md?plain=1#L54-L62
+extern crate libz_sys;
+
 #[test]
 fn create_context() {
     use std::ptr;


### PR DESCRIPTION
`spng-sys`'s build script currently replicates some of the `libz-sys` logic for ensuring that the binaries and libraries generated by the Rust compiler have a suitable Zlib implementation linked in. However, `libz-sys` already emits such linking instructions in all cases, and is better aware of every Zlib build quirk than us, especially on cross-compilation scenarios.

Conceptually, the above paragraph points out something strange: if `libz-sys` already instructs rustc to link to Zlib, why does `spng-sys` do that too? After experimentation, I've found that's done to work around rustc dropping the link flags of dependency crates it deems unused, and `libz-sys` was one of them, as no Rust code referred to anything on `libz-sys`. Therefore, the correct way to get those link flags honored is to make rustc believe `libz-sys` is actually used, which can be done with a dummy `extern crate` statement. This is the same technique used by dtolnay's `link-cplusplus` crate.

These changes implement the correctness improvement detailed above, which renders `spng-sys` build more robust in cross-compilation scenarios I've found, and significantly simplifies its build script.