### PR TITLE
Fixes #11 by storing `RawContext:reader` as `Option<NonNull<R>>` instead of `Option<Box<R>>`

### DIFF
--- a/spng/src/lib.rs
+++ b/spng/src/lib.rs
@@ -166,7 +166,7 @@ pub struct Limits {
     pub max_height: u32,
 }
 
-const PNG_U32_MAX: u32 = std::u32::MAX / 2 - 1;
+const PNG_U32_MAX: u32 = u32::MAX / 2 - 1;
 
 impl Default for Limits {
     fn default() -> Limits {

--- a/spng/src/raw.rs
+++ b/spng/src/raw.rs
@@ -8,8 +8,7 @@ use crate::{
 use self::chunk::*;
 
 use spng_sys as sys;
-use std::{io, marker::PhantomData, mem, mem::MaybeUninit, slice};
-
+use std::{io, marker::PhantomData, mem, mem::MaybeUninit, slice, ptr::NonNull};
 unsafe extern "C" fn read_fn<R: io::Read>(
     _: *mut sys::spng_ctx,
     user: *mut libc::c_void,
@@ -72,7 +71,7 @@ impl<T> ChunkAvail<T> for Result<T, Error> {
 #[derive(Debug)]
 pub struct RawContext<R> {
     raw: *mut sys::spng_ctx,
-    reader: Option<Box<R>>,
+    reader: Option<NonNull<R>>,
 }
 
 impl<R> Drop for RawContext<R> {
@@ -80,6 +79,11 @@ impl<R> Drop for RawContext<R> {
         if !self.raw.is_null() {
             unsafe {
                 sys::spng_ctx_free(self.raw);
+            }
+        }  
+        if let Some(reader) = self.reader {
+            unsafe {
+                drop(Box::from_raw(reader.as_ptr()));
             }
         }
     }
@@ -476,11 +480,11 @@ impl<R> RawContext<R> {
 impl<R: io::Read> RawContext<R> {
     /// Set the input `png` stream reader. The input buffer or stream may only be set once per context.
     pub fn set_png_stream(&mut self, reader: R) -> Result<(), Error> {
-        let mut boxed = Box::new(reader);
-        let user = boxed.as_mut() as *mut R as *mut _;
-        self.reader = Some(boxed);
+        let boxed = Box::new(reader);
+        let unboxed = Box::into_raw(boxed);
+        self.reader = NonNull::new(unboxed);
         let read_fn: sys::spng_read_fn = Some(read_fn::<R>);
-        unsafe { check_err(sys::spng_set_png_stream(self.raw, read_fn, user)) }
+        unsafe { check_err(sys::spng_set_png_stream(self.raw, read_fn, unboxed as *mut _)) }
     }
 }
 

--- a/spng/src/raw.rs
+++ b/spng/src/raw.rs
@@ -8,7 +8,7 @@ use crate::{
 use self::chunk::*;
 
 use spng_sys as sys;
-use std::{io, marker::PhantomData, mem, mem::MaybeUninit, slice, ptr::NonNull};
+use std::{io, marker::PhantomData, mem, mem::MaybeUninit, ptr::NonNull, slice};
 unsafe extern "C" fn read_fn<R: io::Read>(
     _: *mut sys::spng_ctx,
     user: *mut libc::c_void,
@@ -80,7 +80,7 @@ impl<R> Drop for RawContext<R> {
             unsafe {
                 sys::spng_ctx_free(self.raw);
             }
-        }  
+        }
         if let Some(reader) = self.reader {
             unsafe {
                 drop(Box::from_raw(reader.as_ptr()));
@@ -484,7 +484,13 @@ impl<R: io::Read> RawContext<R> {
         let unboxed = Box::into_raw(boxed);
         self.reader = NonNull::new(unboxed);
         let read_fn: sys::spng_read_fn = Some(read_fn::<R>);
-        unsafe { check_err(sys::spng_set_png_stream(self.raw, read_fn, unboxed as *mut _)) }
+        unsafe {
+            check_err(sys::spng_set_png_stream(
+                self.raw,
+                read_fn,
+                unboxed as *mut _,
+            ))
+        }
     }
 }
 


### PR DESCRIPTION
This fixes #11 by "unwrapping" the Box in `set_png_stream`. To avoid a memory leak, `RawContext` will now re-wrap the `Box` in its `Drop` implementation. 